### PR TITLE
allow attributedTitles to be set on actionButtons

### DIFF
--- a/Source/SwipeAction.swift
+++ b/Source/SwipeAction.swift
@@ -29,6 +29,11 @@ public class SwipeAction: NSObject {
     ///
     /// - note: You must specify a title or an image.
     public var title: String?
+
+    /// The attributedTitle for a button
+    ///
+    /// - note: If non-nil, this property will be used over title.
+    public var attributedTitle: NSAttributedString?
     
     /// The style applied to the action button.
     public var style: SwipeActionStyle
@@ -93,6 +98,14 @@ public class SwipeAction: NSObject {
     */
     public init(style: SwipeActionStyle, title: String?, handler: ((SwipeAction, IndexPath) -> Void)?) {
         self.title = title
+        self.style = style
+        self.handler = handler
+    }
+
+    public init(style: SwipeActionStyle,
+                attributedTitle: NSAttributedString?,
+                handler: ((SwipeAction, IndexPath) -> Void)?) {
+        self.attributedTitle = attributedTitle
         self.style = style
         self.handler = handler
     }

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -49,10 +49,15 @@ class SwipeActionButton: UIButton {
         titleLabel?.numberOfLines = 0
         
         accessibilityLabel = action.accessibilityLabel
-        
-        setTitle(action.title, for: .normal)
-        setTitleColor(tintColor, for: .normal)
-        setTitleColor(highlightedTextColor, for: .highlighted)
+
+        if let attributedTitle = action.attributedTitle {
+            setAttributedTitle(attributedTitle, for: .normal)
+        } else {
+            setTitle(action.title, for: .normal)
+            setTitleColor(tintColor, for: .normal)
+            setTitleColor(highlightedTextColor, for: .highlighted)
+        }
+
         setImage(action.image, for: .normal)
         setImage(action.highlightedImage ?? action.image, for: .highlighted)
     }
@@ -74,12 +79,18 @@ class SwipeActionButton: UIButton {
     }
     
     func titleBoundingRect(with size: CGSize) -> CGRect {
-        guard let title = currentTitle, let font = titleLabel?.font else { return .zero }
-        
-        return title.boundingRect(with: size,
-                                  options: [.usesLineFragmentOrigin],
-                                  attributes: [NSAttributedStringKey.font: font],
-                                  context: nil).integral
+        let sharedOptions = [NSStringDrawingOptions.usesLineFragmentOrigin]
+        if let title = currentTitle, let font = titleLabel?.font {
+            return title.boundingRect(with: size,
+                                      options: sharedOptions,
+                                      attributes: [NSAttributedStringKey.font: font],
+                                      context: nil).integral
+        } else if let attributedTitle = currentAttributedTitle {
+            return attributedTitle.boundingRect(with: size,
+                                                options: sharedOptions,
+                                                context: nil).integral
+        }
+        return .zero
     }
     
     override func titleRect(forContentRect contentRect: CGRect) -> CGRect {


### PR DESCRIPTION
This change allows action buttons to have an attributed title as opposed to simply text.